### PR TITLE
OSAI-45 - Fix redis insight setup docker

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -74,7 +74,6 @@ services:
     build:
       context: redis-insight-setup
       dockerfile: ./Dockerfile
-    command: sh -c "/usr/local/bin/setup-connection.sh"
     environment:
       REDIS_CONNECTION_HOST: "host.docker.internal"
       REDIS_CONNECTION_PORT: "6379"

--- a/redis-insight-setup/Dockerfile
+++ b/redis-insight-setup/Dockerfile
@@ -1,6 +1,8 @@
 FROM curlimages/curl:latest
 
 COPY setup-connection.sh setup-connection.sh
-RUN dos2unix setup-connection.sh
+
+# Remove any non-compliant line endings
+RUN  sed -i 's/\r$//' setup-connection.sh
 
 ENTRYPOINT ["sh", "setup-connection.sh"]

--- a/redis-insight-setup/Dockerfile
+++ b/redis-insight-setup/Dockerfile
@@ -1,5 +1,6 @@
 FROM curlimages/curl:latest
 
-COPY setup-connection.sh /usr/local/bin/setup-connection.sh
+COPY setup-connection.sh setup-connection.sh
+RUN dos2unix setup-connection.sh
 
-ENTRYPOINT []
+ENTRYPOINT ["sh", "setup-connection.sh"]

--- a/redis-insight-setup/setup-connection.sh
+++ b/redis-insight-setup/setup-connection.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-sleep 30s
+
+sleep 5
 
 response=$(curl -s -X "GET" "http://host.docker.internal:5540/api/databases/")
 
-if [[ "$response" == "[]" ]] ; then
+if [ "$response" == "[]" ] ; then
   echo "Creating Redis connection"
 
   curl -s -X "POST" "http://host.docker.internal:5540/api/databases/" \

--- a/redis-insight-setup/setup-connection.sh
+++ b/redis-insight-setup/setup-connection.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/sh
 sleep 30s
 
 response=$(curl -s -X "GET" "http://host.docker.internal:5540/api/databases/")


### PR DESCRIPTION
## Description

I don't know how the redis-insight-setup Docker image ever worked, but there were several problems that needed fixing:

* non-unix-compliant line endings
* Using bash rather than sh syntax

To test, `docker compose up` - The script now executes with a 0 return code, and sets up the redis browser at http://localhost:5540/ to be connected to our database

## Changelog
- 
