### PR TITLE
Local model report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ node_modules/
 
 /logs/*
 /backend/logs/*
+/backend/reports/*

--- a/backend/src/agents/report_agent.py
+++ b/backend/src/agents/report_agent.py
@@ -1,6 +1,7 @@
 import asyncio
-import json
 import logging
+import json
+from aiohttp import ClientTimeout
 
 from src.llm.llm import LLMFile
 from src.agents import Agent
@@ -77,13 +78,79 @@ class ReportAgent(Agent):
 
         return f"{report}\n\n{report_conclusion}"
 
-    async def get_company_name(self, file: LLMFile) -> str:
+    async def create_local_report(self, file: LLMFile, materiality_topics: dict[str, str]) -> str:
+        materiality = materiality_topics if materiality_topics else "No Materiality topics identified."
+        timeout = ClientTimeout(total=60*10)
+
+        logger.info("Starting report generation process")
+        overview = await self.llm.chat_with_file(
+            self.model,
+            system_prompt=engine.load_prompt("create-report-overview"),
+            user_prompt="Generate an ESG report about the attached document.",
+            files=[file],
+            agent="report",
+            timeout=timeout
+        ) 
+
+        categories = {}
+
+        for category in QUESTIONS.keys():
+            categories[category] = []
+            for question in QUESTIONS[category]:
+                logger.info(f"Processing report question for category: {category}")
+                task = await self.llm.chat_with_file(
+                    self.model,
+                    system_prompt=engine.load_prompt("report-question-system-prompt"),
+                    user_prompt=question["prompt"],
+                    files=[file],
+                    agent="report",
+                    timeout=timeout
+                )
+                categories[category].append({
+                    "report_heading": question["report_heading"],
+                    "task": task
+                })
+        
+        logger.info("Processing materiality section")
+        materiality = await self.llm.chat_with_file(
+            self.model,
+            system_prompt=engine.load_prompt("create-report-materiality"),
+            user_prompt=engine.load_prompt("create-report-materiality-user-prompt", materiality=materiality),
+            files=[file],
+            agent="report",
+            timeout=timeout
+        )
+
+        esg_report_result = ""
+        for category in categories.keys():
+            esg_report_result += f"\n## {category}\n"
+            for i, task in enumerate(categories[category], start=1):
+                esg_report_result += f"\n### {i}. {task['report_heading']}\n{task['task']}\n"
+
+        report = engine.load_template(
+            template_name="report-template",
+            overview=overview,
+            esg_report_result=esg_report_result,
+            materiality=materiality,
+        )
+
+        report_conclusion = await self.llm.chat(
+            self.model,
+            system_prompt=engine.load_prompt("create-report-conclusion"),
+            user_prompt=f"The document is as follows\n{report}",
+            agent="report"
+        )
+
+        return f"{report}\n\n{report_conclusion}"
+
+    async def get_company_name(self, file: LLMFile, create_local_report: bool) -> str:
+        system_prompt_file = "find-company-name-from-file-system-prompt-name-only" if create_local_report else "find-company-name-from-file-system-prompt"
         response = await self.llm.chat_with_file(
             self.model,
-            system_prompt=engine.load_prompt("find-company-name-from-file-system-prompt"),
+            system_prompt=engine.load_prompt(system_prompt_file),
             user_prompt=engine.load_prompt("find-company-name-from-file-user-prompt"),
             files=[file],
             agent="report",
-            return_json=True
+            return_json = not create_local_report
         )
-        return json.loads(response)["company_name"]
+        return response if create_local_report else json.loads(response)["company_name"]

--- a/backend/src/agents/report_agent.py
+++ b/backend/src/agents/report_agent.py
@@ -1,8 +1,7 @@
 import asyncio
 import logging
-import json
-from aiohttp import ClientTimeout
 
+from aiohttp import ClientTimeout
 from src.llm.llm import LLMFile
 from src.agents import Agent
 from src.prompts import PromptEngine
@@ -13,7 +12,7 @@ engine = PromptEngine()
 
 
 class ReportAgent(Agent):
-    async def create_report(self, file: LLMFile, materiality_topics: dict[str, str]) -> str:
+    async def create_report_async(self, file: LLMFile, materiality_topics: dict[str, str]) -> str:
         materiality = materiality_topics if materiality_topics else "No Materiality topics identified."
 
         async with asyncio.TaskGroup() as tg:
@@ -78,7 +77,7 @@ class ReportAgent(Agent):
 
         return f"{report}\n\n{report_conclusion}"
 
-    async def create_local_report(self, file: LLMFile, materiality_topics: dict[str, str]) -> str:
+    async def create_report_synchronous(self, file: LLMFile, materiality_topics: dict[str, str]) -> str:
         materiality = materiality_topics if materiality_topics else "No Materiality topics identified."
         timeout = ClientTimeout(total=60*10)
 
@@ -92,24 +91,23 @@ class ReportAgent(Agent):
             timeout=timeout
         )
 
-        categories = {}
-
-        for category in QUESTIONS.keys():
-            categories[category] = []
-            for question in QUESTIONS[category]:
-                logger.info(f"Processing report question for category: {category}")
-                task = await self.llm.chat_with_file(
-                    self.model,
-                    system_prompt=engine.load_prompt("report-question-system-prompt"),
-                    user_prompt=question["prompt"],
-                    files=[file],
-                    agent="report",
-                    timeout=timeout
-                )
-                categories[category].append({
-                    "report_heading": question["report_heading"],
-                    "task": task
-                })
+        categorized_tasks = {
+                category: [
+                    {
+                        "report_heading": question["report_heading"],
+                        "task": await self.llm.chat_with_file(
+                            self.model,
+                            system_prompt=engine.load_prompt("report-question-system-prompt"),
+                            user_prompt=question["prompt"],
+                            files=[file],
+                            agent="report",
+                            timeout=timeout
+                        ),
+                    }
+                    for question in QUESTIONS[category]
+                ]
+                for category in QUESTIONS.keys()
+            }
 
         logger.info("Processing materiality section")
         materiality = await self.llm.chat_with_file(
@@ -122,9 +120,9 @@ class ReportAgent(Agent):
         )
 
         esg_report_result = ""
-        for category in categories.keys():
+        for category in categorized_tasks.keys():
             esg_report_result += f"\n## {category}\n"
-            for i, task in enumerate(categories[category], start=1):
+            for i, task in enumerate(categorized_tasks[category], start=1):
                 esg_report_result += f"\n### {i}. {task['report_heading']}\n{task['task']}\n"
 
         report = engine.load_template(
@@ -143,17 +141,13 @@ class ReportAgent(Agent):
 
         return f"{report}\n\n{report_conclusion}"
 
-    async def get_company_name(self, file: LLMFile, create_local_report: bool) -> str:
-        system_prompt_file = (
-            "find-company-name-from-file-system-prompt-name-only" if create_local_report
-            else "find-company-name-from-file-system-prompt"
-        )
+    async def get_company_name(self, file: LLMFile) -> str:
         response = await self.llm.chat_with_file(
             self.model,
-            system_prompt=engine.load_prompt(system_prompt_file),
+            system_prompt=engine.load_prompt("find-company-name-from-file-system-prompt-name-only"),
             user_prompt=engine.load_prompt("find-company-name-from-file-user-prompt"),
             files=[file],
             agent="report",
-            return_json = not create_local_report
+            return_json=False
         )
-        return response if create_local_report else json.loads(response)["company_name"]
+        return response

--- a/backend/src/agents/report_agent.py
+++ b/backend/src/agents/report_agent.py
@@ -90,7 +90,7 @@ class ReportAgent(Agent):
             files=[file],
             agent="report",
             timeout=timeout
-        ) 
+        )
 
         categories = {}
 
@@ -110,7 +110,7 @@ class ReportAgent(Agent):
                     "report_heading": question["report_heading"],
                     "task": task
                 })
-        
+
         logger.info("Processing materiality section")
         materiality = await self.llm.chat_with_file(
             self.model,
@@ -144,7 +144,10 @@ class ReportAgent(Agent):
         return f"{report}\n\n{report_conclusion}"
 
     async def get_company_name(self, file: LLMFile, create_local_report: bool) -> str:
-        system_prompt_file = "find-company-name-from-file-system-prompt-name-only" if create_local_report else "find-company-name-from-file-system-prompt"
+        system_prompt_file = (
+            "find-company-name-from-file-system-prompt-name-only" if create_local_report
+            else "find-company-name-from-file-system-prompt"
+        )
         response = await self.llm.chat_with_file(
             self.model,
             system_prompt=engine.load_prompt(system_prompt_file),

--- a/backend/src/agents/report_agent.py
+++ b/backend/src/agents/report_agent.py
@@ -144,7 +144,7 @@ class ReportAgent(Agent):
     async def get_company_name(self, file: LLMFile) -> str:
         response = await self.llm.chat_with_file(
             self.model,
-            system_prompt=engine.load_prompt("find-company-name-from-file-system-prompt-name-only"),
+            system_prompt=engine.load_prompt("find-company-name-from-file-system-prompt"),
             user_prompt=engine.load_prompt("find-company-name-from-file-user-prompt"),
             files=[file],
             agent="report",

--- a/backend/src/directors/report_director.py
+++ b/backend/src/directors/report_director.py
@@ -1,5 +1,7 @@
+import datetime
 import sys
 from fastapi import HTTPException
+from src.utils import Config
 from src.llm.llm import LLMFile
 from src.session.file_uploads import (
     FileUpload,
@@ -8,9 +10,12 @@ from src.session.file_uploads import (
     update_session_file_uploads
 )
 from src.agents import get_report_agent, get_materiality_agent
+from pathlib import Path
 
 MAX_FILE_SIZE = 40 * 1024 * 1024
-
+REPORT_DIR = Path("reports")
+REPORT_DIR.mkdir(exist_ok=True)
+config = Config()
 
 def prepare_file_for_report(file_contents: bytes, filename: str, file_id:  str):
     file_size = sys.getsizeof(file_contents)
@@ -34,11 +39,13 @@ async def create_report_from_file(file_contents: bytes, filename: str, file_id: 
 
     report_agent = get_report_agent()
 
-    company_name = await report_agent.get_company_name(file)
+    create_local_report = config.report_agent_llm == "lmstudio"
+
+    company_name = await report_agent.get_company_name(file, create_local_report)
 
     topics = await get_materiality_agent().list_material_topics_for_company(company_name)
 
-    report = await report_agent.create_report(file, topics)
+    report = await report_agent.create_local_report(file, topics) if create_local_report else await report_agent.create_report(file, topics)
 
     report_response = ReportResponse(
         filename=filename,
@@ -46,6 +53,13 @@ async def create_report_from_file(file_contents: bytes, filename: str, file_id: 
         report=report,
         answer=create_report_chat_message(filename, company_name, topics),
     )
+
+    if create_local_report:
+        timestamp = datetime.datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
+        report_file_name = f"{filename.split('.')[0]}_{timestamp}.md"
+        filepath = f"{REPORT_DIR}/{report_file_name}"
+        with open(filepath, "w") as text_file:
+            text_file.write(report)
 
     store_report(report_response)
 

--- a/backend/src/directors/report_director.py
+++ b/backend/src/directors/report_director.py
@@ -1,6 +1,7 @@
 import datetime
 import sys
 from fastapi import HTTPException
+from backend.src.agents.report_agent import ReportAgent
 from src.utils import Config
 from src.llm.llm import LLMFile
 from src.session.file_uploads import (
@@ -41,14 +42,11 @@ async def create_report_from_file(file_contents: bytes, filename: str, file_id: 
 
     create_local_report = config.report_agent_llm == "lmstudio"
 
-    company_name = await report_agent.get_company_name(file, create_local_report)
+    company_name = await report_agent.get_company_name(file)
 
     topics = await get_materiality_agent().list_material_topics_for_company(company_name)
 
-    report = (
-        await report_agent.create_local_report(file, topics) if create_local_report
-        else await report_agent.create_report(file, topics)
-    )
+    report = await create_report(file, topics, create_local_report, report_agent)
 
     report_response = ReportResponse(
         filename=filename,
@@ -59,7 +57,7 @@ async def create_report_from_file(file_contents: bytes, filename: str, file_id: 
 
     if create_local_report:
         timestamp = datetime.datetime.now().strftime("%d-%m-%Y_%H-%M-%S")
-        report_file_name = f"{filename.split('.')[0]}_{timestamp}.md"
+        report_file_name = f"{Path(filename).stem}_{timestamp}.md"
         filepath = f"{REPORT_DIR}/{report_file_name}"
         with open(filepath, "w") as text_file:
             text_file.write(report)
@@ -80,3 +78,14 @@ def create_report_chat_message(file_name: str, company_name: str, topics: dict[s
         f"The following materiality topics were identified for {company_name} which the report focuses on:\n\n"
         f"{topics_summary}"
     )
+
+async def create_report(
+        file: LLMFile,
+        materiality_topics: dict[str, str],
+        create_local_report: bool,
+        report_agent: ReportAgent
+    ) -> str:
+    if create_local_report:
+        return await report_agent.create_report_synchronous(file, materiality_topics)
+    else:
+        return await report_agent.create_report_async(file, materiality_topics)

--- a/backend/src/directors/report_director.py
+++ b/backend/src/directors/report_director.py
@@ -45,7 +45,10 @@ async def create_report_from_file(file_contents: bytes, filename: str, file_id: 
 
     topics = await get_materiality_agent().list_material_topics_for_company(company_name)
 
-    report = await report_agent.create_local_report(file, topics) if create_local_report else await report_agent.create_report(file, topics)
+    report = (
+        await report_agent.create_local_report(file, topics) if create_local_report
+        else await report_agent.create_report(file, topics)
+    )
 
     report_response = ReportResponse(
         filename=filename,

--- a/backend/src/directors/report_director.py
+++ b/backend/src/directors/report_director.py
@@ -1,7 +1,7 @@
 import datetime
 import sys
 from fastapi import HTTPException
-from backend.src.agents.report_agent import ReportAgent
+from src.agents.report_agent import ReportAgent
 from src.utils import Config
 from src.llm.llm import LLMFile
 from src.session.file_uploads import (

--- a/backend/src/llm/llm.py
+++ b/backend/src/llm/llm.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from os import PathLike
 from typing import Any, Coroutine, Dict, Optional, Union
 
+from aiohttp import ClientTimeout
+
 from src.utils.usage_recorder import UsageRecorder, CSVUsageRecorder
 
 from .count_calls import count_calls
@@ -78,6 +80,7 @@ class LLM(ABC, metaclass=LLMMeta):
         files: list[LLMFile],
         agent: str,
         return_json: bool = False,
+        timeout: ClientTimeout | None = None
     ) -> Coroutine:
         pass
 

--- a/backend/src/llm/lmstudio.py
+++ b/backend/src/llm/lmstudio.py
@@ -8,6 +8,7 @@ from src.utils import Config
 from src.session.file_uploads import get_file_content_for_filename, set_file_content_for_filename
 from src.utils.file_utils import extract_text
 from .llm import LLM, LLMFile
+from aiohttp import ClientTimeout
 
 logger = logging.getLogger(__name__)
 config = Config()
@@ -20,7 +21,7 @@ class LMStudio(LLM):
     This implementation uses aiohttp to directly call LM Studio's API endpoints.
     """
 
-    async def chat(self, model, system_prompt: str, user_prompt: str, agent: str, return_json=False) -> str:
+    async def chat(self, model, system_prompt: str, user_prompt: str, agent: str, return_json=False, timeout: ClientTimeout | None = None) -> str:
         logger.debug(
             "Called LMStudio llm. Waiting on response with prompt {0}.".format(str([system_prompt, user_prompt]))
         )
@@ -63,7 +64,7 @@ class LMStudio(LLM):
         start_time = time.time()
         try:
             async with aiohttp.ClientSession() as session:
-                async with session.post(url, json=payload, headers=headers) as response:
+                async with session.post(url, json=payload, headers=headers, timeout=timeout) as response:
                     response_text = await response.text()
                     duration = time.time() - start_time
                     logger.debug(f"LM Studio API raw response: {response_text}")
@@ -182,7 +183,7 @@ class LMStudio(LLM):
             return f"Error: The LLM returned invalid JSON format: {content[:100]}..."
 
     async def chat_with_file(
-        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False
+        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False, timeout: ClientTimeout | None = None
     ) -> str:
         try:
             file_contents = []
@@ -202,7 +203,7 @@ class LMStudio(LLM):
             user_prompt += combined_content
 
             logger.info(f"Sending request with {len(files)} files attached to the prompt")
-            result = await self.chat(model, system_prompt, user_prompt, agent, return_json)
+            result = await self.chat(model, system_prompt, user_prompt, agent, return_json, timeout=timeout)
 
             return result
         except Exception as file_error:

--- a/backend/src/llm/lmstudio.py
+++ b/backend/src/llm/lmstudio.py
@@ -21,7 +21,15 @@ class LMStudio(LLM):
     This implementation uses aiohttp to directly call LM Studio's API endpoints.
     """
 
-    async def chat(self, model, system_prompt: str, user_prompt: str, agent: str, return_json=False, timeout: ClientTimeout | None = None) -> str:
+    async def chat(
+            self,
+            model,
+            system_prompt: str,
+            user_prompt: str,
+            agent: str,
+            return_json=False,
+            timeout: ClientTimeout | None = None
+    ) -> str:
         logger.debug(
             "Called LMStudio llm. Waiting on response with prompt {0}.".format(str([system_prompt, user_prompt]))
         )
@@ -183,7 +191,14 @@ class LMStudio(LLM):
             return f"Error: The LLM returned invalid JSON format: {content[:100]}..."
 
     async def chat_with_file(
-        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False, timeout: ClientTimeout | None = None
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        files: list[LLMFile],
+        agent: str,
+        return_json=False,
+        timeout: ClientTimeout | None = None
     ) -> str:
         try:
             file_contents = []

--- a/backend/src/llm/mistral.py
+++ b/backend/src/llm/mistral.py
@@ -65,7 +65,8 @@ class Mistral(LLM):
         user_prompt: str,
         files: list[LLMFile],
         agent: str,
-        return_json=False
+        return_json=False,
+        timeout=None
     ) -> str:
         try:
             for file in files:

--- a/backend/src/llm/openai.py
+++ b/backend/src/llm/openai.py
@@ -88,7 +88,14 @@ class OpenAI(LLM):
             return "An error occurred while processing the request."
 
     async def chat_with_file(
-        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False, timeout=None
+        self,
+        model: str,
+        system_prompt: str,
+        user_prompt: str,
+        files: list[LLMFile],
+        agent: str,
+        return_json=False,
+        timeout=None
     ) -> str:
         client = AsyncOpenAI(api_key=config.openai_key)
         start_time = time.time()

--- a/backend/src/llm/openai.py
+++ b/backend/src/llm/openai.py
@@ -88,7 +88,7 @@ class OpenAI(LLM):
             return "An error occurred while processing the request."
 
     async def chat_with_file(
-        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False
+        self, model: str, system_prompt: str, user_prompt: str, files: list[LLMFile], agent: str, return_json=False, timeout=None
     ) -> str:
         client = AsyncOpenAI(api_key=config.openai_key)
         start_time = time.time()

--- a/backend/src/prompts/templates/find-company-name-from-file-system-prompt-name-only.j2
+++ b/backend/src/prompts/templates/find-company-name-from-file-system-prompt-name-only.j2
@@ -1,4 +1,0 @@
-You will receive a file containing information about a company. Your task is to identify the name of the company the file is about.
-
-Output only the company name as they are commonly known.
-Do not include additional text, explanations.

--- a/backend/src/prompts/templates/find-company-name-from-file-system-prompt-name-only.j2
+++ b/backend/src/prompts/templates/find-company-name-from-file-system-prompt-name-only.j2
@@ -1,0 +1,4 @@
+You will receive a file containing information about a company. Your task is to identify the name of the company the file is about.
+
+Output only the company name as they are commonly known.
+Do not include additional text, explanations.

--- a/backend/src/prompts/templates/find-company-name-from-file-system-prompt.j2
+++ b/backend/src/prompts/templates/find-company-name-from-file-system-prompt.j2
@@ -2,8 +2,3 @@ You will receive a file containing information about a company. Your task is to 
 
 Output only the company name as they are commonly known.
 Do not include additional text, explanations.
-
-Output Requirements:
-Your output will be a single line in JSON format with no markdown or formatting, as shown below:
-
-{ "company_name": "COMPANY_NAME" }

--- a/backend/tests/agents/report_agent_test.py
+++ b/backend/tests/agents/report_agent_test.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import src.agents.report_agent as report_agent_module
 
@@ -20,7 +20,7 @@ def mock_engine(monkeypatch):
 
 @pytest.fixture
 def mock_questions(monkeypatch):
-    QUESTIONS = {
+    mock_questions = {
         "Environment": [
             {"report_heading": "Env Heading 1", "prompt": "Env Q1"},
             {"report_heading": "Env Heading 2", "prompt": "Env Q2"},
@@ -29,8 +29,8 @@ def mock_questions(monkeypatch):
             {"report_heading": "Soc Heading 1", "prompt": "Soc Q1"},
         ]
     }
-    monkeypatch.setattr(report_agent_module, "QUESTIONS", QUESTIONS)
-    return QUESTIONS
+    monkeypatch.setattr(report_agent_module, "QUESTIONS", mock_questions)
+    return mock_questions
 
 @pytest.fixture
 def agent(mock_llm, mock_engine, mock_questions):
@@ -47,7 +47,7 @@ async def test_get_company_name(agent):
     result = await agent.get_company_name(file)
     assert result == "Test Company"
     agent.llm.chat_with_file.assert_awaited_once()
-    
+
 @pytest.mark.asyncio
 async def test_create_report_synchronous(agent, mock_engine, mock_questions):
     agent.llm.chat_with_file.side_effect = [

--- a/backend/tests/agents/report_agent_test.py
+++ b/backend/tests/agents/report_agent_test.py
@@ -1,0 +1,87 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import src.agents.report_agent as report_agent_module
+
+@pytest.fixture
+def mock_llm():
+    llm = MagicMock()
+    llm.chat_with_file = AsyncMock()
+    llm.chat = AsyncMock()
+    return llm
+
+@pytest.fixture
+def mock_engine(monkeypatch):
+    engine = MagicMock()
+    engine.load_prompt = MagicMock(side_effect=lambda name, **kwargs: f"prompt-{name}")
+    engine.load_template = MagicMock(side_effect=lambda template_name, **kwargs: f"template-{template_name}-{kwargs}")
+    monkeypatch.setattr(report_agent_module, "engine", engine)
+    return engine
+
+@pytest.fixture
+def mock_questions(monkeypatch):
+    QUESTIONS = {
+        "Environment": [
+            {"report_heading": "Env Heading 1", "prompt": "Env Q1"},
+            {"report_heading": "Env Heading 2", "prompt": "Env Q2"},
+        ],
+        "Social": [
+            {"report_heading": "Soc Heading 1", "prompt": "Soc Q1"},
+        ]
+    }
+    monkeypatch.setattr(report_agent_module, "QUESTIONS", QUESTIONS)
+    return QUESTIONS
+
+@pytest.fixture
+def agent(mock_llm, mock_engine, mock_questions):
+    class DummyAgent(report_agent_module.ReportAgent):
+        def __init__(self):
+            self.llm = mock_llm
+            self.model = "test-model"
+    return DummyAgent()
+
+@pytest.mark.asyncio
+async def test_get_company_name(agent):
+    agent.llm.chat_with_file.return_value = "Test Company"
+    file = MagicMock()
+    result = await agent.get_company_name(file)
+    assert result == "Test Company"
+    agent.llm.chat_with_file.assert_awaited_once()
+    
+@pytest.mark.asyncio
+async def test_create_report_synchronous(agent, mock_engine, mock_questions):
+    agent.llm.chat_with_file.side_effect = [
+        "Overview text",
+        "Env Answer 1",
+        "Env Answer 2",
+        "Soc Answer 1",
+        "Materiality text"
+    ]
+    agent.llm.chat.return_value = "Conclusion text"
+    file = MagicMock()
+    materiality_topics = {"topic1": "desc1"}
+
+    result = await agent.create_report_synchronous(file, materiality_topics)
+    assert "Overview text" in result
+    assert "Env Answer 1" in result
+    assert "Env Answer 2" in result
+    assert "Soc Answer 1" in result
+    assert "Materiality text" in result
+    assert "Conclusion text" in result
+    assert "report-template" in result
+
+@pytest.mark.asyncio
+async def test_create_report_synchronous_no_materiality(agent, mock_engine):
+    agent.llm.chat_with_file.side_effect = [
+        "Overview text",
+        "Env Answer 1",
+        "Env Answer 2",
+        "Soc Answer 1",
+        "Materiality text"
+    ]
+    agent.llm.chat.return_value = "Conclusion text"
+    file = MagicMock()
+    materiality_topics = {}
+
+    await agent.create_report_synchronous(file, materiality_topics)
+    assert "No Materiality topics identified." in mock_engine.load_prompt.call_args_list[5][1]['materiality']

--- a/backend/tests/directors/report_director_test.py
+++ b/backend/tests/directors/report_director_test.py
@@ -10,7 +10,12 @@ from src.directors.report_director import create_report_from_file, prepare_file_
 
 mock_topics = {"topic1": "topic1 description", "topic2": "topic2 description"}
 mock_report = "#Report on upload as markdown"
-expected_answer = ("Your report for test.txt is ready to view.\n\n"
+expected_answer_async = ("Your report for report-test-1.txt is ready to view.\n\n"
+                   "The following materiality topics were identified for "
+                   "CompanyABC which the report focuses on:\n\n"
+                   "topic1\ntopic1 description\n\n"
+                   "topic2\ntopic2 description")
+expected_answer_sync = ("Your report for report-test-2.txt is ready to view.\n\n"
                    "The following materiality topics were identified for "
                    "CompanyABC which the report focuses on:\n\n"
                    "topic1\ntopic1 description\n\n"
@@ -39,16 +44,19 @@ async def test_prepare_file_for_report(mocker):
 
 @pytest.mark.asyncio
 async def test_create_report_from_file(mocker):
-    file_upload = FileUpload(id="1", filename="test.txt", content="test", upload_id=None)
+    file_upload = FileUpload(id="1", filename="report-test-1.txt", content="report-test-1", upload_id=None)
 
     mock_id = uuid.uuid4()
     mocker.patch("uuid.uuid4", return_value=mock_id)
-    filename = "test.txt"
+    filename = "report-test-1.txt"
+
+    mock_config = mocker.patch("src.directors.report_director.config")
+    mock_config.report_agent_llm = "openai"
 
     # Mock report agent
     mock_report_agent = mocker.AsyncMock()
     mock_report_agent.get_company_name.return_value = "CompanyABC"
-    mock_report_agent.create_report.return_value = mock_report
+    mock_report_agent.create_report_async.return_value = mock_report
     mocker.patch("src.directors.report_director.get_report_agent", return_value=mock_report_agent)
 
     # Mock materiality agent
@@ -60,16 +68,65 @@ async def test_create_report_from_file(mocker):
     mock_store_report = mocker.patch("src.directors.report_director.store_report", return_value=file_upload)
 
     file = UploadFile(
-        file=BytesIO(b"test"), size=12, headers=Headers({"content-type": "text/plain"}), filename=filename
+        file=BytesIO(b"report-test-1"), size=12, headers=Headers({"content-type": "text/plain"}), filename=filename
     )
     file_contents = await file.read()
     response = await create_report_from_file(file_contents, filename, str(mock_id) )
 
-    expected_response = {"filename": filename, "id": str(mock_id), "report": mock_report, "answer": expected_answer}
+    expected_response = {"filename": filename, "id": str(mock_id), "report": mock_report, "answer": expected_answer_async}
 
     mock_store_report.assert_called_once_with(expected_response)
 
     mock_materiality_agent.list_material_topics_for_company.assert_called_once_with("CompanyABC")
 
     assert response == expected_response
+
+@pytest.mark.asyncio
+async def test_create_report_from_file_lmstudio(mocker, tmp_path):
+    file_upload = FileUpload(id="2", filename="report-test-2.txt", content="report-test-2", upload_id=None)
+    mock_id = uuid.uuid4()
+    mocker.patch("uuid.uuid4", return_value=mock_id)
+    filename = "report-test-2.txt"
+
+    # Mock config to use lmstudio
+    mock_config = mocker.patch("src.directors.report_director.config")
+    mock_config.report_agent_llm = "lmstudio"
+
+    # Mock report agent
+    mock_report_agent = mocker.AsyncMock()
+    mock_report_agent.get_company_name.return_value = "CompanyABC"
+    mock_report_agent.create_report_synchronous.return_value = mock_report
+    mocker.patch("src.directors.report_director.get_report_agent", return_value=mock_report_agent)
+
+    # Mock materiality agent
+    mock_materiality_agent = mocker.AsyncMock()
+    mock_materiality_agent.list_material_topics_for_company.return_value = mock_topics
+    mocker.patch("src.directors.report_director.get_materiality_agent", return_value=mock_materiality_agent)
+
+    # Patch REPORT_DIR to tmp_path
+    mocker.patch("src.directors.report_director.REPORT_DIR", tmp_path)
+    mock_store_report = mocker.patch("src.directors.report_director.store_report", return_value=file_upload)
+
+    file = UploadFile(
+        file=BytesIO(b"test2"), size=12, headers=Headers({"content-type": "text/plain"}), filename=filename
+    )
+    file_contents = await file.read()
+    response = await create_report_from_file(file_contents, filename, str(mock_id))
+
+    expected_response = {
+        "filename": filename,
+        "id": str(mock_id),
+        "report": mock_report,
+        "answer": expected_answer_sync
+    }
+
+    mock_store_report.assert_called_once_with(expected_response)
+    mock_materiality_agent.list_material_topics_for_company.assert_called_once_with("CompanyABC")
+    assert response == expected_response
+
+    # Check that a markdown file was created in tmp_path
+    files = list(tmp_path.glob("*.md"))
+    assert len(files) == 1
+    with open(files[0], "r") as f:
+        assert f.read() == mock_report
 

--- a/backend/tests/directors/report_director_test.py
+++ b/backend/tests/directors/report_director_test.py
@@ -73,7 +73,12 @@ async def test_create_report_from_file(mocker):
     file_contents = await file.read()
     response = await create_report_from_file(file_contents, filename, str(mock_id) )
 
-    expected_response = {"filename": filename, "id": str(mock_id), "report": mock_report, "answer": expected_answer_async}
+    expected_response = {
+        "filename": filename,
+        "id": str(mock_id),
+        "report": mock_report,
+        "answer": expected_answer_async
+    }
 
     mock_store_report.assert_called_once_with(expected_response)
 

--- a/backend/tests/llm/mock_llm.py
+++ b/backend/tests/llm/mock_llm.py
@@ -13,5 +13,6 @@ class MockLLM(LLM):
         files: list[LLMFile],
         agent: str,
         return_json: bool = False,
+        timeout=None,
     ) -> str:
         return "mocked response"


### PR DESCRIPTION
## Description

Updates to the report agent to make it easier to generate a report using LM studio.

- Added new method to report agent `create_local_report`: this creates the report by making calls to the llm one by one, rather than all at once
- Get company name will expect just a string back from the llm if running through LM Studio - this is because I found I was frequently not getting the expected json response and all we need is the string
- Report director will use the relevant methods depending on if the report agent is using LM Studio or not
- Added an option to set the timeout in the LLM requests - LM Studio can take some time so being able to increase the timeout on this is helpful