### PR TITLE
Osai 89/fix validation issue

### DIFF
--- a/backend/src/agents/validator_agent.py
+++ b/backend/src/agents/validator_agent.py
@@ -10,7 +10,7 @@ engine = PromptEngine()
 
 class ValidatorAgent(Agent):
     async def validate(self, utterance: str) -> str:
-        answer = await self.llm.chat(self.model, engine.load_prompt("validator"), utterance, agent="validator")
+        answer = await self.llm.chat(self.model, engine.load_prompt("validator"), utterance, agent="validator", return_json=True)
         response = json.loads(answer)['response']
         await publish_log_info(LogPrefix.USER, f"Validating: '{utterance}' Answer: '{response}'", __name__)
 

--- a/backend/src/agents/validator_agent.py
+++ b/backend/src/agents/validator_agent.py
@@ -10,7 +10,13 @@ engine = PromptEngine()
 
 class ValidatorAgent(Agent):
     async def validate(self, utterance: str) -> str:
-        answer = await self.llm.chat(self.model, engine.load_prompt("validator"), utterance, agent="validator", return_json=True)
+        answer = await self.llm.chat(
+            self.model,
+            engine.load_prompt("validator"),
+            utterance,
+            agent="validator",
+            return_json=True
+        )
         response = json.loads(answer)['response']
         await publish_log_info(LogPrefix.USER, f"Validating: '{utterance}' Answer: '{response}'", __name__)
 


### PR DESCRIPTION
## Description

When validating a response, the result did not always come back as a proper json format and this would result in an error when trying to parse it. The validator agent has been updated to pass in `return_json=True` which tells the model to return in a json format

## Changelog
- Update validator agent to pass `return_json=True`
