### PR TITLE
OSAI-85 - Cache Session ID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,40 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Python: Uvicorn (src.api:app)",
-            "type": "debugpy",
-            "request": "launch",
-            "module": "uvicorn",
-            "args": [
-                "src.api:app",
-                "--port",
-                "8250",
-                "--reload"
-            ],
-            "cwd": "${workspaceFolder}/backend",
-            "console": "integratedTerminal",
-            "justMyCode": true,
-            "jinja": true,
-            "env": {
-                "PYTHONPATH": "${workspaceFolder}"
-            }
-        },
-                {
-            "name": "Frontend: npm start",
-            "type": "node",
-            "request": "launch",
-            "cwd": "${workspaceFolder}/frontend",
-            "runtimeExecutable": "npm",
-            "runtimeArgs": [
-                "start"
-            ],
-            "console": "integratedTerminal"
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Uvicorn (src.api:app)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "args": ["src.api:app", "--port", "8250", "--reload"],
+      "cwd": "${workspaceFolder}/backend",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "jinja": true,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}"
+      }
+    },
+    {
+        "name": "Python: Launch Evaluator",
+        "type": "debugpy",
+        "request": "launch",
+        "program": "enhanced_run_evaluation_pipeline.py",
+        "args": ["../../../library/ScottLogicEnvironmentalImpactReport2024.pdf", "1"],
+        "cwd": "${workspaceFolder}/backend/tests/Ragas/utils",
+        "justMyCode": true,
+        "env": {
+            "PYTHONPATH": "${workspaceFolder}",
         }
-    ]
+    },
+    {
+      "name": "Frontend: npm start",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["start"],
+      "console": "integratedTerminal"
+    }
+  ]
 }

--- a/backend/tests/Ragas/utils/modules/api_client.py
+++ b/backend/tests/Ragas/utils/modules/api_client.py
@@ -4,6 +4,7 @@ API Client for interacting with the OpenInferESG API.
 import requests
 import time
 import socket
+import uuid
 from typing import Dict, Optional, Any, Tuple
 
 class OpenInferESGClient:
@@ -23,6 +24,10 @@ class OpenInferESGClient:
             "Accept": "application/json",
             "Connection": "keep-alive"
         })
+        self.session.cookies.clear()
+        id = str(uuid.uuid4())
+        self.session.cookies.set("session_id", id)
+        print("Session ID: {id}")
 
     def check_availability(self) -> bool:
         """


### PR DESCRIPTION
## Description

This change pins the session ID for requests sent by the evaluation script - The result of this change is that chat messages attach the relevant document information alongside questions to OpenAI.

Note that there still appears to be a problem with the attaching documents, in that the content of them is not consumable by the LLM - This happens for both manual running in the UI and this evaluation script.

I've also added a launch profile to support debugging the evaluation script.

## Changelog
- 
